### PR TITLE
Add content-type and file size validators

### DIFF
--- a/app/validators/content_type_validator.rb
+++ b/app/validators/content_type_validator.rb
@@ -29,7 +29,7 @@ class ContentTypeValidator < ActiveModel::EachValidator
 
     # Ensure array and ensure symbols
     types = [types].flatten.compact.map(&:to_sym)
-    puts "types: #{types.inspect}"
+
     allowed_types = []
     types.each do |types|
       if types.in?(keys)

--- a/app/validators/content_type_validator.rb
+++ b/app/validators/content_type_validator.rb
@@ -15,7 +15,7 @@ class ContentTypeValidator < ActiveModel::EachValidator
     calendar:     %i[ics],
     spreadsheet:  %i[xlsx xls],
     video:        %i[mpeg mpg mp3 m4a mpg4 aac webm mp4 m4v],
-  }
+  }.freeze
 
   def validate_each(record, attribute, value)
     # Support for optional attachments
@@ -25,7 +25,7 @@ class ContentTypeValidator < ActiveModel::EachValidator
     values = EXPANSIONS.values.flatten
     options = instance_values["options"]
     message = options.try(:[], :message) || "must have a valid content type"
-    types = options[:in]
+    types = options[:with] || options[:in]
 
     # Ensure array and ensure symbols
     types = [types].flatten.compact.map(&:to_sym)

--- a/app/validators/content_type_validator.rb
+++ b/app/validators/content_type_validator.rb
@@ -1,0 +1,50 @@
+#
+# Custom validator for attachments' content types
+#
+# @example
+#
+#   -> validates :image, content_type: :image
+#   -> validates :image, content_type: [:jpg, :webp]
+#   -> validates :image, content_type: [:image, :pdf]
+#   -> validates :image, content_type: { in: :image, message: 'must be a valid image' }
+#
+class ContentTypeValidator < ActiveModel::EachValidator
+  EXPANSIONS = {
+    image:        %i[png jpeg jpg jpe pjpeg gif bmp svg webp],
+    document:     %i[text txt docx doc xml pdf csv],
+    calendar:     %i[ics],
+    spreadsheet:  %i[xlsx xls],
+    video:        %i[mpeg mpg mp3 m4a mpg4 aac webm mp4 m4v],
+  }
+
+  def validate_each(record, attribute, value)
+    # Support for optional attachments
+    return unless value.present? && value.attached?
+
+    keys   = EXPANSIONS.keys
+    values = EXPANSIONS.values.flatten
+    options = instance_values["options"]
+    message = options.try(:[], :message) || "must have a valid content type"
+    types = options[:in]
+
+    # Ensure array and ensure symbols
+    types = [types].flatten.compact.map(&:to_sym)
+    puts "types: #{types.inspect}"
+    allowed_types = []
+    types.each do |types|
+      if types.in?(keys)
+        allowed_types << EXPANSIONS[types]
+      elsif types.in?(values)
+        allowed_types << types
+      else
+        raise("unknown content_type types: #{types}")
+      end
+    end
+    allowed_types = allowed_types.flatten.map(&:to_sym).uniq
+
+    unless value.filename.extension.to_sym.in?(allowed_types)
+      record.errors.add(attribute, message)
+    end
+
+  end
+end

--- a/app/validators/size_validator.rb
+++ b/app/validators/size_validator.rb
@@ -1,0 +1,23 @@
+#
+# Custom validator for file sizes
+#
+# @example
+#
+#   -> validates :image, size: { less_than: 2.megabytes }
+#   -> validates :image, size: { less_than: 2.megabytes, message: 'is too large, please upload a file smaller than 2MB' }
+#
+class SizeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless value.present? && value.attached?
+
+    options = instance_values["options"]
+
+    max_size = options.try(:[], :less_than) || 2.megabytes
+    message = options.try(:[], :message) || "is too large, please upload a file smaller than #{max_size / 1.megabyte}MB"
+
+    if value.blob.byte_size > max_size
+      record.errors.add(attribute, message)
+    end
+
+  end
+end


### PR DESCRIPTION
MIME types extracted from Rails `Mime::EXTENSION_LOOKUP`

Separated tested with each of the following in a model with an `has_one_attached :image` 

```
    validates :image, content_type: :image
    validates :image, content_type: [:jpg, :webp]
    validates :image, content_type: [:image, :pdf]
    validates :image, content_type: { in: :image, message: 'must be a valid image' }

    validates :image, size: { less_than: 5.megabytes }
```