### PR TITLE
More performant datatable resource collections

### DIFF
--- a/app/models/effective/resources/sql.rb
+++ b/app/models/effective/resources/sql.rb
@@ -22,11 +22,6 @@ module Effective
         klass.unscoped.table
       end
 
-      def max_id
-        return 999999 unless klass.respond_to?(:unscoped)
-        @max_id ||= klass.unscoped.maximum(klass.primary_key).to_i
-      end
-
       def sql_column(name)
         column = column(name)
         return nil unless table && column


### PR DESCRIPTION
This is a performance fix.

Instead of making a COUNT vs the has_many collection then maybe pull upto 100 records.

We now do this in just 1x sql query. Pull all the records with the right scope one time.