### PR TITLE
Normalize and validate pagination parameters

### DIFF
--- a/app/controllers/concerns/effective/select2_ajax_controller.rb
+++ b/app/controllers/concerns/effective/select2_ajax_controller.rb
@@ -33,7 +33,7 @@ module Effective
       # Paginate
       if !skip_paginate
         per_page = 50
-        page = EffectiveResources.normalize_page!(params[:page])
+        page = EffectiveResources.normalize_page(params[:page]) || 1
         last = (collection.reselect(:id).count.to_f / per_page).ceil
         more = page < last
   

--- a/app/controllers/concerns/effective/select2_ajax_controller.rb
+++ b/app/controllers/concerns/effective/select2_ajax_controller.rb
@@ -33,7 +33,7 @@ module Effective
       # Paginate
       if !skip_paginate
         per_page = 50
-        page = (params[:page] || 1).to_i
+        page = EffectiveResources.normalize_page(params[:page])
         last = (collection.reselect(:id).count.to_f / per_page).ceil
         more = page < last
   

--- a/app/controllers/concerns/effective/select2_ajax_controller.rb
+++ b/app/controllers/concerns/effective/select2_ajax_controller.rb
@@ -33,7 +33,7 @@ module Effective
       # Paginate
       if !skip_paginate
         per_page = 50
-        page = EffectiveResources.normalize_page(params[:page])
+        page = EffectiveResources.normalize_page!(params[:page])
         last = (collection.reselect(:id).count.to_f / per_page).ceil
         more = page < last
   

--- a/app/models/concerns/acts_as_paginable.rb
+++ b/app/models/concerns/acts_as_paginable.rb
@@ -27,7 +27,7 @@ module ActsAsPaginable
 
     scope :paginate, -> (page: nil, per_page: nil) {
       per_page = (per_page || default_per_page).to_i
-      page = (page || 1).to_i
+      page = EffectiveResources.normalize_page(page)
       offset = [(page - 1), 0].max * (per_page).to_i
 
       all.limit(per_page).offset(offset)

--- a/app/models/concerns/acts_as_paginable.rb
+++ b/app/models/concerns/acts_as_paginable.rb
@@ -27,7 +27,7 @@ module ActsAsPaginable
 
     scope :paginate, -> (page: nil, per_page: nil) {
       per_page = (per_page || default_per_page).to_i
-      page = EffectiveResources.normalize_page(page)
+      page = EffectiveResources.normalize_page!(page)
       offset = [(page - 1), 0].max * (per_page).to_i
 
       all.limit(per_page).offset(offset)

--- a/app/models/concerns/acts_as_paginable.rb
+++ b/app/models/concerns/acts_as_paginable.rb
@@ -27,7 +27,7 @@ module ActsAsPaginable
 
     scope :paginate, -> (page: nil, per_page: nil) {
       per_page = (per_page || default_per_page).to_i
-      page = EffectiveResources.normalize_page!(page)
+      page = EffectiveResources.normalize_page(page) || 1
       offset = [(page - 1), 0].max * (per_page).to_i
 
       all.limit(per_page).offset(offset)

--- a/lib/effective_resources.rb
+++ b/lib/effective_resources.rb
@@ -87,7 +87,7 @@ module EffectiveResources
 
   # Utilities
 
-  def self.normalize_page(value)
+  def self.normalize_page!(value)
     return 1 if value.nil? || value == ''
 
     valid = (value.is_a?(Integer) && value.positive?) ||

--- a/lib/effective_resources.rb
+++ b/lib/effective_resources.rb
@@ -88,8 +88,14 @@ module EffectiveResources
   # Utilities
 
   def self.normalize_page(value)
-    page = value.try(:to_i)
-    page && page > 0 ? page : 1
+    return 1 if value.nil? || value == ''
+
+    valid = (value.is_a?(Integer) && value.positive?) ||
+      (value.is_a?(String) && value.match?(/\A[1-9]\d*\z/))
+
+    raise ActiveRecord::RecordNotFound, "Page #{value.inspect} is invalid" unless valid
+
+    value.to_i
   end
 
   def self.validate_page!(page, collection_count:, per_page:)

--- a/lib/effective_resources.rb
+++ b/lib/effective_resources.rb
@@ -87,6 +87,18 @@ module EffectiveResources
 
   # Utilities
 
+  def self.normalize_page(value)
+    page = value.try(:to_i)
+    page && page > 0 ? page : 1
+  end
+
+  def self.validate_page!(page, collection_count:, per_page:)
+    last = [(collection_count.to_f / per_page).ceil, 1].max
+    raise ActiveRecord::RecordNotFound, "Page #{page} does not exist" if page > last
+
+    page
+  end
+
   # This looks up the best class give the name
   # If the Tenant is present, use those classes first.
   def self.best(name)

--- a/lib/effective_resources.rb
+++ b/lib/effective_resources.rb
@@ -87,18 +87,16 @@ module EffectiveResources
 
   # Utilities
 
-  def self.normalize_page!(value)
+  def self.normalize_page(value)
     return 1 if value.nil? || value == ''
-
-    valid = (value.is_a?(Integer) && value.positive?) ||
-      (value.is_a?(String) && value.match?(/\A[1-9]\d*\z/))
-
-    raise ActiveRecord::RecordNotFound, "Page #{value.inspect} is invalid" unless valid
-
-    value.to_i
+    return value if value.is_a?(Integer) && value.positive?
+    return value.to_i if value.is_a?(String) && value.match?(/\A[1-9]\d*\z/)
   end
 
-  def self.validate_page!(page, collection_count:, per_page:)
+  def self.validate_page!(value, collection_count:, per_page:)
+    page = normalize_page(value)
+    raise ActiveRecord::RecordNotFound, "Page #{value.inspect} is invalid" unless page
+
     last = [(collection_count.to_f / per_page).ceil, 1].max
     raise ActiveRecord::RecordNotFound, "Page #{page} does not exist" if page > last
 

--- a/test/effective_resources_test.rb
+++ b/test/effective_resources_test.rb
@@ -6,12 +6,18 @@ class EffectiveResources::Test < ActiveSupport::TestCase
   end
 
   test 'normalize page' do
-    [2, '2', '2abc'].each do |page|
+    [2, '2'].each do |page|
       assert_equal 2, EffectiveResources.normalize_page(page)
     end
 
-    [nil, '', 'invalid', 0, -1, [], {}, ActionController::Parameters.new(page: 2)].each do |page|
+    [nil, ''].each do |page|
       assert_equal 1, EffectiveResources.normalize_page(page)
+    end
+
+    ['03', '2abc', 'invalid', 0, -1, [], {}, ActionController::Parameters.new(page: 2)].each do |page|
+      assert_raises(ActiveRecord::RecordNotFound) do
+        EffectiveResources.normalize_page(page)
+      end
     end
   end
 

--- a/test/effective_resources_test.rb
+++ b/test/effective_resources_test.rb
@@ -5,19 +5,17 @@ class EffectiveResources::Test < ActiveSupport::TestCase
     assert Thing.create!(title: "Title", body: "Body")
   end
 
-  test 'normalize page!' do
+  test 'normalize page' do
     [2, '2'].each do |page|
-      assert_equal 2, EffectiveResources.normalize_page!(page)
+      assert_equal 2, EffectiveResources.normalize_page(page)
     end
 
     [nil, ''].each do |page|
-      assert_equal 1, EffectiveResources.normalize_page!(page)
+      assert_equal 1, EffectiveResources.normalize_page(page)
     end
 
     ['03', '2abc', 'invalid', 0, -1, [], {}, ActionController::Parameters.new(page: 2)].each do |page|
-      assert_raises(ActiveRecord::RecordNotFound) do
-        EffectiveResources.normalize_page!(page)
-      end
+      assert_nil EffectiveResources.normalize_page(page)
     end
   end
 
@@ -25,6 +23,12 @@ class EffectiveResources::Test < ActiveSupport::TestCase
     assert_equal 1, EffectiveResources.validate_page!(1, collection_count: 0, per_page: 10)
     assert_equal 4, EffectiveResources.validate_page!(4, collection_count: 40, per_page: 10)
     assert_equal 5, EffectiveResources.validate_page!(5, collection_count: 41, per_page: 10)
+
+    error = assert_raises(ActiveRecord::RecordNotFound) do
+      EffectiveResources.validate_page!('03', collection_count: 40, per_page: 10)
+    end
+
+    assert_equal 'Page "03" is invalid', error.message
 
     error = assert_raises(ActiveRecord::RecordNotFound) do
       EffectiveResources.validate_page!(5, collection_count: 40, per_page: 10)

--- a/test/effective_resources_test.rb
+++ b/test/effective_resources_test.rb
@@ -5,18 +5,18 @@ class EffectiveResources::Test < ActiveSupport::TestCase
     assert Thing.create!(title: "Title", body: "Body")
   end
 
-  test 'normalize page' do
+  test 'normalize page!' do
     [2, '2'].each do |page|
-      assert_equal 2, EffectiveResources.normalize_page(page)
+      assert_equal 2, EffectiveResources.normalize_page!(page)
     end
 
     [nil, ''].each do |page|
-      assert_equal 1, EffectiveResources.normalize_page(page)
+      assert_equal 1, EffectiveResources.normalize_page!(page)
     end
 
     ['03', '2abc', 'invalid', 0, -1, [], {}, ActionController::Parameters.new(page: 2)].each do |page|
       assert_raises(ActiveRecord::RecordNotFound) do
-        EffectiveResources.normalize_page(page)
+        EffectiveResources.normalize_page!(page)
       end
     end
   end

--- a/test/effective_resources_test.rb
+++ b/test/effective_resources_test.rb
@@ -4,4 +4,30 @@ class EffectiveResources::Test < ActiveSupport::TestCase
   test 'thing is valid' do
     assert Thing.create!(title: "Title", body: "Body")
   end
+
+  test 'normalize page' do
+    [2, '2', '2abc'].each do |page|
+      assert_equal 2, EffectiveResources.normalize_page(page)
+    end
+
+    [nil, '', 'invalid', 0, -1, [], {}, ActionController::Parameters.new(page: 2)].each do |page|
+      assert_equal 1, EffectiveResources.normalize_page(page)
+    end
+  end
+
+  test 'validate page' do
+    assert_equal 1, EffectiveResources.validate_page!(1, collection_count: 0, per_page: 10)
+    assert_equal 4, EffectiveResources.validate_page!(4, collection_count: 40, per_page: 10)
+    assert_equal 5, EffectiveResources.validate_page!(5, collection_count: 41, per_page: 10)
+
+    error = assert_raises(ActiveRecord::RecordNotFound) do
+      EffectiveResources.validate_page!(5, collection_count: 40, per_page: 10)
+    end
+
+    assert_equal 'Page 5 does not exist', error.message
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      EffectiveResources.validate_page!(2, collection_count: 0, per_page: 10)
+    end
+  end
 end

--- a/test/models/acts_as_paginable_test.rb
+++ b/test/models/acts_as_paginable_test.rb
@@ -17,10 +17,9 @@ class ActsAsPaginableTest < ActiveSupport::TestCase
     assert_equal Post.paginate(page: 2).count, Post.default_per_page
     assert_equal Post.paginate(page: 3).count, 0
 
-    first_page = Post.paginate(page: 1).pluck(:id)
-    assert_equal first_page, Post.paginate(page: []).pluck(:id)
-    assert_equal first_page, Post.paginate(page: {}).pluck(:id)
-    assert_equal first_page, Post.paginate(page: ActionController::Parameters.new(page: 2)).pluck(:id)
+    [[], {}, '03', '2abc', ActionController::Parameters.new(page: 2)].each do |page|
+      assert_raises(ActiveRecord::RecordNotFound) { Post.paginate(page: page) }
+    end
 
     # Tests [per_page]
     assert_equal Post.paginate(per_page: 1).count, 1

--- a/test/models/acts_as_paginable_test.rb
+++ b/test/models/acts_as_paginable_test.rb
@@ -17,6 +17,11 @@ class ActsAsPaginableTest < ActiveSupport::TestCase
     assert_equal Post.paginate(page: 2).count, Post.default_per_page
     assert_equal Post.paginate(page: 3).count, 0
 
+    first_page = Post.paginate(page: 1).pluck(:id)
+    assert_equal first_page, Post.paginate(page: []).pluck(:id)
+    assert_equal first_page, Post.paginate(page: {}).pluck(:id)
+    assert_equal first_page, Post.paginate(page: ActionController::Parameters.new(page: 2)).pluck(:id)
+
     # Tests [per_page]
     assert_equal Post.paginate(per_page: 1).count, 1
     assert_equal Post.paginate(per_page: 1, page: 2).count, 1

--- a/test/models/acts_as_paginable_test.rb
+++ b/test/models/acts_as_paginable_test.rb
@@ -17,8 +17,10 @@ class ActsAsPaginableTest < ActiveSupport::TestCase
     assert_equal Post.paginate(page: 2).count, Post.default_per_page
     assert_equal Post.paginate(page: 3).count, 0
 
+    first_page = Post.paginate(page: 1).pluck(:id)
+
     [[], {}, '03', '2abc', ActionController::Parameters.new(page: 2)].each do |page|
-      assert_raises(ActiveRecord::RecordNotFound) { Post.paginate(page: page) }
+      assert_equal first_page, Post.paginate(page: page).pluck(:id)
     end
 
     # Tests [per_page]


### PR DESCRIPTION
## Summary

- add shared page normalization for malformed scalar and structured inputs
- use it in ActsAsPaginable and Select2 pagination
- add upper-bound validation that raises ActiveRecord::RecordNotFound

## Tests

- mise exec -- bin/rails test test/effective_resources_test.rb test/models/acts_as_paginable_test.rb